### PR TITLE
Fix error message for invalid wavelet dimensionality

### DIFF
--- a/zrad/filtering/filtering.py
+++ b/zrad/filtering/filtering.py
@@ -52,7 +52,9 @@ class Filtering:
                                        rotation_invariance=self.filtering_params["rotation_invariance"]
                                        )
             else:
-                raise ValueError(f"Filter_dimension {self.filtering_params['filter_dimension']} is not supported.")
+                raise ValueError(
+                    f"Dimensionality {self.filtering_params['dimensionality']} is not supported."
+                )
         else:
             raise ValueError(f"Filter {filtering_method} is not supported.")
         return my_filter


### PR DESCRIPTION
## Summary
- correct error message for wavelet filter dimensionality handling

## Testing
- `pytest -q -c /tmp/pytest.ini` *(fails: ModuleNotFoundError: No module named 'numpy')*

------
https://chatgpt.com/codex/tasks/task_e_6840147c64ec832f8c144b16df6d5f1d